### PR TITLE
💄 style : DailySpaceimage 원문 디폴트 표시 및 이미지에 링크 추가

### DIFF
--- a/src/components/daily/DailySpaceimage.tsx
+++ b/src/components/daily/DailySpaceimage.tsx
@@ -1,9 +1,11 @@
 import { useLoaderData } from "react-router-dom";
 import { LoaderData } from "../../types/daily";
 import { useTranslate } from "../../hooks/useTranslate";
+import { useState } from "react";
 
 export default function DailySpaceimage() {
   const { nasa } = useLoaderData() as LoaderData;
+  const [showTranslation, setShowTranslation] = useState(false);
   const { translation: translation, isLoading } = useTranslate(
     nasa.explanation,
     nasa.date
@@ -25,11 +27,17 @@ export default function DailySpaceimage() {
         {/* 오른쪽 이미지 */}
         <div className="w-full h-1/2 sm:w-1/2 sm:h-full bg-[rgba(255,255,255,0.09)] flex justify-start items-center">
           {nasa.media_type === "image" ? (
-            <img
-              src={nasa.url}
-              alt={nasa.title}
-              className="w-full h-full object-cover"
-            />
+            <a
+              href="https://apod.nasa.gov/apod/astropix.html"
+              target="_blank"
+              className="w-full h-full"
+            >
+              <img
+                src={nasa.url}
+                alt={nasa.title}
+                className="w-full h-full object-cover"
+              />
+            </a>
           ) : (
             <div className="w-full flex justify-center items-center">
               <h1 className="text-center">이미지가 없습니다.</h1>
@@ -37,19 +45,50 @@ export default function DailySpaceimage() {
           )}
         </div>
         {/* 왼쪽 내용 */}
-        <div className="w-full h-1/2 sm:w-1/2 sm:h-full bg-[rgba(255,255,255,0.09)] text-[var(--white)] flex flex-col justify-start items-start px-12">
-          <div className="my-5  md:my-12  w-full">
-            <h1 className="md:text-xl text-sm font-bold mb-2 md:mb-5">
+        <div className="w-full sm:w-1/2 md:h-full bg-[rgba(255,255,255,0.09)] text-[var(--white)] flex flex-col items-start px-6 py-6 md:px-12 md:py-12">
+          <div className=" h-full w-full flex flex-col justify-between">
+            <h1 className="md:text-2xl text-sm font-medium mb-2 md:mb-5">
               {nasa.title}
             </h1>
-            {isLoading ? (
-              <div className="space-y-2 animate-pulse w-full">
-                <div className="h-4 bg-gray-500 rounded w-full"></div>
-              </div>
+            {showTranslation ? (
+              <>
+                <div className="flex-1">
+                  {isLoading ? (
+                    <div className="space-y-2 animate-pulse w-full">
+                      <div className="h-4 bg-gray-500 rounded w-full"></div>
+                      <div className="h-4 bg-gray-500 rounded w-full"></div>
+                    </div>
+                  ) : (
+                    <p className="text-xs md:text-base line-clamp-10 md:line-clamp-14 whitespace-pre-wrap leading-5 md:leading-7 tracking-wide">
+                      {translation}
+                    </p>
+                  )}
+                </div>
+                <div className="w-full flex justify-end ">
+                  <button
+                    onClick={() => setShowTranslation(false)}
+                    className="text-[10px]  md:text-base text-[color:var(--gray-200)] cursor-pointer mt-1"
+                  >
+                    원문보기
+                  </button>{" "}
+                </div>
+              </>
             ) : (
-              <p className="text-xs md:text-base line-clamp-12 md:line-clamp-18 whitespace-pre-wrap leading-normal">
-                {translation}
-              </p>
+              <>
+                <div className="flex-1">
+                  <p className="text-xs md:text-base line-clamp-10 md:line-clamp-14 whitespace-pre-wrap leading-5 md:leading-7 tracking-wide">
+                    {nasa.explanation}
+                  </p>
+                </div>
+                <div className="w-full flex justify-end ">
+                  <button
+                    onClick={() => setShowTranslation(true)}
+                    className="text-[10px] md:text-base text-[color:var(--gray-200)] cursor-pointer mt-1"
+                  >
+                    번역보기
+                  </button>{" "}
+                </div>
+              </>
             )}
           </div>
         </div>


### PR DESCRIPTION
## #️⃣ Issue Number

#43 

## 📝 요약(Summary)

- `DailySpaceimage` 컴포넌트에서 설명 텍스트가 기본적으로 원문을 보여주도록 변경
- 사용자가 “번역보기” 버튼을 누르면 번역된 텍스트로 전환
- 이미지에 <a> 태그를 추가하여 클릭 시 NASA APOD 공식 페이지인 https://apod.nasa.gov/apod/astropix.html 링크로 이동하도록 처리


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

![Screenshot 2025-06-12 at 2 46 06 PM](https://github.com/user-attachments/assets/65bec4ad-bcb2-455e-9fe4-4ab1ac9c63f9)

> 디폴트 화면

![Screenshot 2025-06-12 at 2 45 55 PM](https://github.com/user-attachments/assets/2b0c7f88-08dc-45d2-9a43-fdea15ea02d1)

> 번역 보기 버튼 클릭 시


## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
