### PR TITLE
♻️ daily만 로딩걸리도록 개선

### DIFF
--- a/src/routes/layouts/RootLayout.tsx
+++ b/src/routes/layouts/RootLayout.tsx
@@ -6,7 +6,9 @@ import LoadingSpinner from '../../components/common/LoadingSpinner';
 export default function RootLayout() {
   // 로딩상태 관리
   const navigation = useNavigation();
-  const isLoading = navigation.location?.pathname.startsWith('/daily');
+  const isLoading =
+    navigation.state === 'loading' &&
+    navigation.location?.pathname === '/daily';
 
   return (
     <>


### PR DESCRIPTION
## #️⃣ Issue Number

## 📝 요약(Summary)

전체로딩이아닌 daily로 갈때만 로딩이 걸리게 수정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

https://github.com/user-attachments/assets/5ccb3a3b-f292-4fa9-a1b1-2e4c5d8f3af9

daily만 로딩걸리고 퍼즐은 안걸리도록 바꿨습니다.

## 💬 공유사항 to 리뷰어

다른쪽 로딩을 생각을 못했네요 daily만 보느라고 daily만 로딩뜨게 잘작동합니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
